### PR TITLE
Add missing personas and roles to project management documentation

### DIFF
--- a/docs/octoacme-roles-and-personas.md
+++ b/docs/octoacme-roles-and-personas.md
@@ -28,33 +28,174 @@ Developers design, build, test, and deliver software components. They collaborat
 
 ---
 
-## Product Managers
+## Product Owners
 
 ### Role Summary
-Product Managers define what should be built to deliver customer and business value. They own the product vision, prioritize the backlog, and measure outcomes.
+Product Owners define the product vision, maintain the product backlog, and prioritize work based on business value and customer needs. They serve as the bridge between stakeholders and the delivery team.
 
 ### Responsibilities
-- Define problem statements and success metrics
-- Prioritize the roadmap and backlog
-- Collaborate with stakeholders and engineering on trade-offs
-- Validate solutions through user research and metrics
+- Define product vision and strategic direction
+- Maintain and prioritize the product backlog
+- Write and refine user stories with acceptance criteria
+- Collaborate with stakeholders to gather and validate requirements
+- Work closely with Project Manager and development team to ensure alignment
+- Make trade-off decisions between scope, quality, and timeline
 
 ### Goals
-- Maximize customer value and impact
-- Make clear, data-driven prioritization decisions
-- Ensure product-market fit and usability
+- Deliver maximum business value and customer satisfaction
+- Ensure clear prioritization aligned with business strategy
+- Maintain healthy backlog and reduce ambiguity in requirements
 
 ### Typical Communication
-- Weekly alignment with PM and engineering leads
-- Roadmap updates and stakeholder briefings
-- Acceptance criteria and feature specs
+- Sprint planning and backlog refinement sessions
+- Stakeholder updates and feedback sessions
+- User story specifications and acceptance criteria
+- Regular sync with Project Manager and team leads
+
+### Interaction with Other Roles
+- **Developers**: Reviews completed work, provides feedback on implementation
+- **Project Manager**: Collaborates on roadmap, priorities, and release planning
+- **Business Analyst**: Works together on requirement gathering and validation
+- **QA Lead**: Defines acceptance criteria and validates quality standards
+
+---
+
+## Business Analysts
+
+### Role Summary
+Business Analysts gather requirements, clarify user needs, and bridge communication between business stakeholders and technical teams. They help translate business problems into actionable, well-defined requirements.
+
+### Responsibilities
+- Conduct stakeholder interviews and requirements gathering sessions
+- Document and clarify business requirements and user needs
+- Create detailed requirement specifications and user stories
+- Identify gaps and inconsistencies in requirements
+- Facilitate communication between business and technical teams
+- Support trade-off analysis and impact assessments
+- Validate solutions against business requirements
+
+### Goals
+- Ensure clear, unambiguous requirements before development begins
+- Reduce rework and misalignment through thorough requirement analysis
+- Bridge communication gaps between business and technical teams
+
+### Typical Communication
+- Requirement gathering workshops and stakeholder interviews
+- Detailed specification documents and requirement matrices
+- Design review meetings with technical teams
+- Requirements traceability documentation
+
+### Interaction with Other Roles
+- **Product Owner**: Supports backlog refinement and user story creation
+- **Project Manager**: Assists in scope definition and impact analysis
+- **Developers**: Clarifies requirements and answers technical questions
+- **QA Lead**: Ensures requirements are testable and complete
+
+---
+
+## QA Leads
+
+### Role Summary
+QA Leads design and oversee the testing strategy, ensure quality standards are met, coordinate test execution, and communicate defects and quality metrics. They champion quality throughout the project lifecycle.
+
+### Responsibilities
+- Design comprehensive testing strategies aligned with project scope
+- Define quality standards, acceptance criteria, and test plans
+- Coordinate test execution across manual and automated testing
+- Identify, document, and track defects and quality issues
+- Communicate quality metrics and risks to stakeholders
+- Work closely with developers on test coverage and quality gates
+- Collaborate with Product Owner to validate acceptance criteria
+
+### Goals
+- Ensure high-quality deliverables meet acceptance criteria
+- Identify defects early and prevent issues from reaching production
+- Maintain transparency on quality status and risks
+
+### Typical Communication
+- Test plans and test case documentation
+- Quality reports and defect logs
+- Daily testing standups and quality reviews
+- Acceptance criteria validation sessions
+
+### Interaction with Other Roles
+- **Developers**: Collaborates on test coverage, reviews code for testability
+- **Product Owner**: Validates acceptance criteria and quality standards
+- **Project Manager**: Reports quality metrics and risks
+- **Release Manager**: Provides quality sign-off for releases
+
+---
+
+## Release Managers
+
+### Role Summary
+Release Managers plan and manage release activities, coordinate deployment schedules, and ensure smooth delivery to production. They serve as the coordinator for all release-related activities.
+
+### Responsibilities
+- Create and maintain release plans and deployment schedules
+- Coordinate preparation of release notes and deployment documentation
+- Manage deployment activities and coordinate across teams
+- Track release readiness and identify blockers
+- Communicate release status to stakeholders
+- Manage rollback procedures and post-deployment validation
+- Ensure compliance with change management and deployment policies
+
+### Goals
+- Deliver releases on schedule with minimal disruption
+- Ensure smooth, coordinated deployments to production
+- Maintain clear communication and documentation for all releases
+
+### Typical Communication
+- Release plans and deployment schedules
+- Release notes and deployment documentation
+- Release status updates and stakeholder briefings
+- Post-deployment validation reports
+
+### Interaction with Other Roles
+- **Project Manager**: Coordinates release timeline and resource planning
+- **QA Lead**: Ensures quality sign-off before release
+- **Developers**: Coordinates code freeze and deployment preparation
+- **Support/Operations Liaison**: Coordinates handover and operational readiness
+
+---
+
+## Support/Operations Liaisons
+
+### Role Summary
+Support/Operations Liaisons represent support and operations teams in project planning and execution. They identify operational concerns early, ensure operational readiness, and facilitate smooth handover to support teams.
+
+### Responsibilities
+- Represent support and operations perspectives in project planning
+- Identify operational concerns, risks, and requirements early
+- Ensure operational readiness documentation is complete
+- Coordinate knowledge transfer and training for support teams
+- Document operational procedures and troubleshooting guides
+- Review deployment plans for operational viability
+- Provide operational metrics and performance baseline expectations
+
+### Goals
+- Ensure operational readiness and smooth transition to support
+- Minimize operational issues and support disruptions after launch
+- Maintain clear operational documentation and runbooks
+
+### Typical Communication
+- Operational requirements and readiness checklists
+- Support documentation and runbooks
+- Knowledge transfer and training sessions
+- Operational risk assessments and mitigation plans
+
+### Interaction with Other Roles
+- **Project Manager**: Provides operational perspective on planning and risks
+- **Release Manager**: Coordinates operational readiness for releases
+- **Developers**: Reviews technical design for operational supportability
+- **QA Lead**: Validates operational scenarios and performance requirements
 
 ---
 
 ## Project Managers
 
 ### Role Summary
-Project Managers coordinate delivery activities, manage schedules, risks, and communications. They enable the team to deliver on commitments efficiently.
+Project Managers coordinate delivery activities, manage schedules, risks, and communications. They enable the team to deliver on commitments efficiently and maintain alignment across all stakeholders.
 
 ### Responsibilities
 - Create and maintain project plans and timelines
@@ -62,20 +203,33 @@ Project Managers coordinate delivery activities, manage schedules, risks, and co
 - Facilitate meetings (kickoff, planning, retrospectives)
 - Ensure consistent project documentation and status reporting
 - Coordinate cross-team and stakeholder communication
+- Track progress against milestones and identify blockers
+- Manage scope and advocate for realistic timelines
+- Escalate risks and impediments to leadership
 
 ### Goals
 - Deliver projects on time and within scope
 - Minimize unplanned work and escalations
 - Maintain transparency and alignment across stakeholders
+- Enable team productivity and remove blockers
 
 ### Typical Communication
 - Weekly status updates and stakeholder reports
 - Risk registers and decision logs
 - Coordination via project boards and meeting facilitation
+- Stakeholder briefings and executive summaries
+
+### Interaction with Other Roles
+- **Product Owner**: Collaborates on roadmap, priorities, and scope
+- **Developers**: Manages team capacity, addresses blockers
+- **Business Analyst**: Collaborates on requirements and scope definition
+- **QA Lead**: Coordinates quality planning and testing schedules
+- **Release Manager**: Coordinates release planning and resource allocation
+- **Support/Operations Liaison**: Incorporates operational requirements into planning
 
 ---
 
 ## How these personas are used in the exercise
 - Use these persona definitions to frame scenarios and sample interactions in the Skills Exercise.
 - Each persona can be used as a persona prompt for Copilot Spaces to shape role-specific guidance.
-
+- Reference the interaction sections to understand how roles work together and support each project phase.


### PR DESCRIPTION
## Add expanded personas and roles to project management documentation

### Description
This pull request expands the OctoAcme Roles and Personas documentation by adding five new personas that were identified as missing from the project management process documentation.

### Changes
Updated `docs/octoacme-roles-and-personas.md` to include:

**New Personas Added:**
1. **Product Owner** - Defines product vision, maintains backlog, and prioritizes work based on business value
2. **Business Analyst** - Gathers requirements, clarifies user needs, and bridges communication between business and technical teams
3. **QA Lead** - Designs testing strategy, ensures quality standards, and coordinates test execution
4. **Release Manager** - Plans and manages release activities and ensures smooth production delivery
5. **Support/Operations Liaison** - Represents support/operations teams and ensures operational readiness

### Why These Changes Matter
- **Enhanced Clarity**: Each persona now has clear role descriptions, responsibilities, and goals
- **Improved Accountability**: Detailed responsibility definitions reduce ambiguity
- **Better Collaboration**: Added "Interaction with Other Roles" sections show how personas work together
- **Complete Coverage**: Addresses gaps in the original documentation
- **Process Improvement**: Aligns with industry best practices

### Related Issue
Closes #4

### Reviewers
@viswaa-epam